### PR TITLE
171 short year detected

### DIFF
--- a/lib/detectors/date_detector.rb
+++ b/lib/detectors/date_detector.rb
@@ -12,7 +12,7 @@ class DateDetector
   SHORT_ENGLISH_DATE_REGEX = /((?:#{days})-(?:Oct)-\d{4}$)/
   LONG_SLASH_DATE_REGEX = %r{((?:#{days})/(?:#{months})/\d{4}$)}
   FULL_GERMAN_DATE_REGEX =
-    /(\d+\. (?:März|April|September|Oktober|Dezember) \d+)/
+    /(\d+\. (?:März|April|September|Oktober|Dezember) \d{4})/
   FULL_ENGLISH_DATE_REGEX = /(\d{2} (?:March|May|October) \d{4})/
   LONG_HUNGARIAN_DATE_REGEX = /20\d{2}\.(?:#{months})\.(?:#{days})/
 

--- a/spec/detectors/date_detector_spec.rb
+++ b/spec/detectors/date_detector_spec.rb
@@ -511,6 +511,47 @@ describe DateDetector do
     expect(date_strings(dates)).to be_empty
   end
 
+  it "doesn't detect a year that is too short" do
+    create(
+      :word,
+      text: '30.',
+      left: 0.5107913669064749,
+      right: 0.5336821451929366,
+      top: 0.18631530282015718,
+      bottom: 0.19579288025889968
+    )
+
+    create(
+      :word,
+      text: 'September',
+      left: 0.5405493786788751,
+      right: 0.6324395029431,
+      top: 0.18539066111881647,
+      bottom: 0.19879796578825706
+    )
+
+    create(
+      :word,
+      text: '203',
+      left: 0.6383257030739045,
+      right: 0.6644865925441465,
+      top: 0.18631530282015718,
+      bottom: 0.19579288025889968
+    )
+
+    create(
+      :word,
+      text: '6',
+      left: 0.6690647482014388,
+      right: 0.6782210595160235,
+      top: 0.18631530282015718,
+      bottom: 0.19579288025889968
+    )
+
+    dates = DateDetector.filter
+    expect(date_strings(dates)).to be_empty
+  end
+
   def date_strings(date_terms)
     date_terms.map { |date_term| date_term.to_datetime.strftime('%Y-%m-%d') }
   end


### PR DESCRIPTION
Closes #171 
The issue is actually an OCR issue. But this fixes the fact that an incorrect date gets detected that should not.

**Actual data:**
![screen shot 2017-02-03 at 10 23 07](https://cloud.githubusercontent.com/assets/5068494/22586033/ea80007c-e9fa-11e6-82d8-4295b6bd19db.png)

**What gets read:**
![screen shot 2017-02-03 at 10 21 46](https://cloud.githubusercontent.com/assets/5068494/22586005/d1eb8f04-e9fa-11e6-8c41-d781d5300479.png)

