### PR TITLE
Remove old and unecessary argument

### DIFF
--- a/lib/calculations/date_calculation.rb
+++ b/lib/calculations/date_calculation.rb
@@ -31,9 +31,7 @@ class DateCalculation
 
     due_date || begin
       date_relative_to = invoice_date
-      RelativeDateCalculation.new(
-        RelativeDateTerm.dataset
-      ).relative_date(date_relative_to)
+      RelativeDateCalculation.new.relative_date(date_relative_to)
     end
   end
 end


### PR DESCRIPTION
Very simple fix that was just removing an argument that was part of the pre-refactor structure of the recognizer. 

Took a while because I wanted to test as to why the parts of code which invoke this error ie. any due date that is a relative term did make this show up before.

This fixes the described problem and closes #187 