### PR TITLE
210 improve ocr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # Mostly taken from http://blog.giantswarm.io/getting-started-with-microservices-using-ruby-on-rails-and-docker/
 FROM ruby:2.3.1
 
-RUN apt-get update &&  apt-get install -y ghostscript g++ autoconf automake libtool autoconf-archive pkg-config libpng12-dev libjpeg62-turbo-dev libtiff5-dev zlib1g-dev libleptonica-dev && git clone https://github.com/DanBloomberg/leptonica.git && cd leptonica && mkdir m4 && autoreconf -vi && ./autobuild && ./configure && make && make install
-
-RUN git clone --depth 1 https://github.com/tesseract-ocr/tesseract.git && cd tesseract && ./autogen.sh && ./configure --enable-debug && LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make && make install && ldconfig
+RUN apt-get update &&  apt-get install -y ghostscript g++ autoconf automake libtool autoconf-archive pkg-config libpng12-dev libjpeg62-turbo-dev libtiff5-dev zlib1g-dev libleptonica-dev && git clone https://github.com/DanBloomberg/leptonica.git && cd leptonica && mkdir m4 && autoreconf -vi && ./autobuild && ./configure && make && make install && git clone --depth 1 https://github.com/tesseract-ocr/tesseract.git && cd tesseract && ./autogen.sh && ./configure --enable-debug && LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make && make install && ldconfig
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # Mostly taken from http://blog.giantswarm.io/getting-started-with-microservices-using-ruby-on-rails-and-docker/
 FROM ruby:2.3.1
 
-RUN apt-get update &&  apt-get install -y ghostscript tesseract-ocr tesseract-ocr-deu
+RUN apt-get update &&  apt-get install -y ghostscript g++ autoconf automake libtool autoconf-archive pkg-config libpng12-dev libjpeg62-turbo-dev libtiff5-dev zlib1g-dev libleptonica-dev && git clone https://github.com/DanBloomberg/leptonica.git && cd leptonica && mkdir m4 && autoreconf -vi && ./autobuild && ./configure && ./make-for-auto && cd leptonica && sudo make && sudo make install
+
+RUN git clone --depth 1 https://github.com/tesseract-ocr/tesseract.git && cd tesseract && ./autogen.sh && ./configure --enable-debug && LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make && sudo make install && sudo ldconfig
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Mostly taken from http://blog.giantswarm.io/getting-started-with-microservices-using-ruby-on-rails-and-docker/
 FROM ruby:2.3.1
 
-RUN apt-get update &&  apt-get install -y ghostscript g++ autoconf automake libtool autoconf-archive pkg-config libpng12-dev libjpeg62-turbo-dev libtiff5-dev zlib1g-dev libleptonica-dev && git clone https://github.com/DanBloomberg/leptonica.git && cd leptonica && mkdir m4 && autoreconf -vi && ./autobuild && ./configure && ./make-for-auto && cd leptonica && sudo make && sudo make install
+RUN apt-get update &&  apt-get install -y ghostscript g++ autoconf automake libtool autoconf-archive pkg-config libpng12-dev libjpeg62-turbo-dev libtiff5-dev zlib1g-dev libleptonica-dev && git clone https://github.com/DanBloomberg/leptonica.git && cd leptonica && mkdir m4 && autoreconf -vi && ./autobuild && ./configure && make && make install
 
-RUN git clone --depth 1 https://github.com/tesseract-ocr/tesseract.git && cd tesseract && ./autogen.sh && ./configure --enable-debug && LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make && sudo make install && sudo ldconfig
+RUN git clone --depth 1 https://github.com/tesseract-ocr/tesseract.git && cd tesseract && ./autogen.sh && ./configure --enable-debug && LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make && make install && ldconfig
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 # Mostly taken from http://blog.giantswarm.io/getting-started-with-microservices-using-ruby-on-rails-and-docker/
 FROM ruby:2.3.1
 
-RUN apt-get update &&  apt-get install -y ghostscript g++ autoconf automake libtool autoconf-archive pkg-config libpng12-dev libjpeg62-turbo-dev libtiff5-dev zlib1g-dev libleptonica-dev && git clone https://github.com/DanBloomberg/leptonica.git && cd leptonica && mkdir m4 && autoreconf -vi && ./autobuild && ./configure && make && make install && git clone --depth 1 https://github.com/tesseract-ocr/tesseract.git && cd tesseract && ./autogen.sh && ./configure --enable-debug && LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make && make install && ldconfig
+# This installs our libraries and some Tesseract dependencies
+RUN apt-get update &&  apt-get install -y ghostscript g++ autoconf automake libtool autoconf-archive pkg-config libpng12-dev libjpeg62-turbo-dev libtiff5-dev zlib1g-dev libleptonica-dev
+
+# This downloads and compiles Leptonica 1.74, a Tesseract 4.00 dependency
+RUN git clone https://github.com/DanBloomberg/leptonica.git && cd leptonica && mkdir m4 && autoreconf -vi && ./autobuild && ./configure && make && make install
+
+# This downloads and compiles Tesseract 4.00
+RUN git clone --depth 1 https://github.com/tesseract-ocr/tesseract.git && cd tesseract && ./autogen.sh && ./configure --enable-debug && LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make && make install && ldconfig
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1


### PR DESCRIPTION
✨IT✨IS✨DONE✨
Basically just upgrading to Tesseract 4.00 though. It's a bit hard to read because of the mess of commands but basically this installs all of the dependencies for Tesseract, clones and installs Leptonica (another dependency for Tesseract), and clones and installs the newest version of Tesseract.

_Fun problems along the way:_ Our linux version was "too old" because docker, clang++ was being tedious because of python, libjpeg8-dev is outdated, leptonica needed to be manually compiled as well because we needed 1.74 for tesseract 4.00, and _that_ was just a whole beast on it's own. I think it would be a nice blog post or read me because there were about 9 big problems and each of them required a lot of research to solve so it might help someone somewhere 😂 

Also fun, building the image now takes ~15 mins 😳

Closes #210 and closes #147 and closes #70